### PR TITLE
Fix trimExtension function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,3 @@ yarn-cache
 # build
 main.js
 *.js.map
-
-# luckman212
-backups/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ yarn-cache
 # build
 main.js
 *.js.map
+
+# luckman212
+backups/

--- a/main.ts
+++ b/main.ts
@@ -105,6 +105,19 @@ class RecentFilesListView extends ItemView {
         text: currentFile.basename,
       });
 
+      navFile.setAttr('draggable', 'true');
+      navFile.addEventListener('dragstart', (event: DragEvent) => {
+        const file = this.app.metadataCache.getFirstLinkpathDest(
+          currentFile.path,
+          '',
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const dragManager = (this.app as any).dragManager;
+        const dragData = dragManager.dragFile(event, file);
+        dragManager.onDragStart(event, dragData);
+      });
+
       navFile.onClickEvent((event) =>
         this.focusFile(currentFile, event.ctrlKey || event.metaKey),
       );

--- a/main.ts
+++ b/main.ts
@@ -289,7 +289,9 @@ export default class RecentFilesPlugin extends Plugin {
 
   // trimExtension can be used to turn a filename into a basename when
   // interacting with a TAbstractFile that does not have a basename property.
-  private readonly trimExtension = (name: string): string => name.split('.')[0];
+  // private readonly trimExtension = (name: string): string => name.split('.')[0];
+  // from: https://stackoverflow.com/a/4250408/617864
+  private readonly trimExtension = (name: string): string => name.replace(/\.[^/.]+$/, '');
 }
 
 class RecentFilesSettingTab extends PluginSettingTab {

--- a/main.ts
+++ b/main.ts
@@ -172,7 +172,7 @@ export default class RecentFilesPlugin extends Plugin {
   public view: RecentFilesListView;
 
   public async onload(): Promise<void> {
-    console.log('loading plugin');
+    console.log('Recent Files: Loading plugin');
 
     await this.loadData();
 
@@ -220,19 +220,18 @@ export default class RecentFilesPlugin extends Plugin {
   };
 
   public readonly shouldAddFile = (file: FilePath): boolean => {
-    const patterns: string[] = this.data.omittedPaths.filter((path) => path.length > 0)
+    const patterns: string[] = this.data.omittedPaths.filter(
+      (path) => path.length > 0,
+    );
     const fileMatchesRegex = (pattern: string): boolean => {
       try {
-        const re = new RegExp(pattern);
-        const doesMatch: boolean = re.test(file.path);
-        return doesMatch;
+        return new RegExp(pattern).test(file.path);
       } catch (err) {
-        // console.log(err);
+        console.error('Recent Files: Invalid regex pattern: ' + pattern);
         return false;
       }
-    }
-    const shouldAdd: boolean = !(patterns.some(fileMatchesRegex));
-    return shouldAdd;
+    };
+    return !patterns.some(fileMatchesRegex);
   };
 
   private readonly initView = (): void => {
@@ -295,7 +294,8 @@ class RecentFilesSettingTab extends PluginSettingTab {
 
     const fragment = document.createDocumentFragment();
     const link = document.createElement('a');
-    link.href = 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#writing_a_regular_expression_pattern';
+    link.href =
+      'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#writing_a_regular_expression_pattern';
     link.text = 'MDN - Regular expressions';
     fragment.append('RegExp patterns to ignore. One pattern per line. See ');
     fragment.append(link);

--- a/main.ts
+++ b/main.ts
@@ -136,6 +136,13 @@ class RecentFilesListView extends ItemView {
     this.redraw();
   };
 
+  /**
+   * Open the provided file in the most recent leaf.
+   *
+   * @param shouldSplit Whether the file should be opened in a new split, or in
+   * the most recent split. If the most recent split is pinned, this is set to
+   * true.
+   */
   private readonly focusFile = (file: FilePath, shouldSplit = false): void => {
     const targetFile = this.app.vault
       .getFiles()
@@ -143,7 +150,9 @@ class RecentFilesListView extends ItemView {
 
     if (targetFile) {
       let leaf = this.app.workspace.getMostRecentLeaf();
-      if (shouldSplit) {
+
+      const createLeaf = shouldSplit || leaf.getViewState().pinned;
+      if (createLeaf) {
         leaf = this.app.workspace.createLeafBySplit(leaf);
       }
       leaf.openFile(targetFile);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "recent-files-obsidian",
   "name": "Recent Files",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "minAppVersion": "0.11.6",
   "description": "List files by most recently opened",
   "author": "Tony Grosinger",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "recent-files-obsidian",
   "name": "Recent Files",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "minAppVersion": "0.11.6",
   "description": "List files by most recently opened",
   "author": "Tony Grosinger",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recent-files-obsidian",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "List files by most recently opened",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recent-files-obsidian",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "List files by most recently opened",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
I noticed that `trimExtension()` was not doing the right thing on filenames containing extra periods `.` — they were being truncated. This leads to incorrect display in the recent file list.

#### For example, try this- 

1. create a new file
2. rename it to `note about Templater function tp.system`
3. in the recent file list, you'll see:
![image](https://user-images.githubusercontent.com/1992842/115618232-695c2880-a2c0-11eb-897a-307a9a73652d.png)

This PR changes the behavior, using the top-ranked method from https://stackoverflow.com/a/4250408/617864

"Works for me" but let me know what you think.