### PR TITLE
fix trimExtension when filename contains periods

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -289,7 +289,9 @@ export default class RecentFilesPlugin extends Plugin {
 
   // trimExtension can be used to turn a filename into a basename when
   // interacting with a TAbstractFile that does not have a basename property.
-  private readonly trimExtension = (name: string): string => name.split('.')[0];
+  // private readonly trimExtension = (name: string): string => name.split('.')[0];
+  // from: https://stackoverflow.com/a/4250408/617864
+  private readonly trimExtension = (name: string): string => name.replace(/\.[^/.]+$/, '');
 }
 
 class RecentFilesSettingTab extends PluginSettingTab {


### PR DESCRIPTION
I noticed that `trimExtension()` wasn't doing the right thing on filenames containing extra periods — they were being truncated. This leads to incorrect display in the recent file list.

#### For example, try this- 

1. create a new file
2. rename it to `note about Templater function tp.system`
3. in the recent file list, you'll see:
![image](https://user-images.githubusercontent.com/1992842/115618232-695c2880-a2c0-11eb-897a-307a9a73652d.png)
(missing "system")

This simple PR changes the behavior, using the top-ranked method from https://stackoverflow.com/a/4250408/617864

_"Works for me"_ but let me know what you think.

