### PR TITLE
Add context menu and preview hover (close #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Optionally include paths of files which should be excluded from the list.
 
 That's all there is to it!
 
+As with the file explorer view, you can:
+
+* Click items to open, ctrl-click to open in a new pane, right-click for a menu
+* Drag items to an editor to drop a link, to a header to open in a specific pane, or to a file explorer folder to move the file
+* Hover or ctrl-hover to view a content preview (as configured by the "Recent Files" toggle in the "Page Preview" settings)
+
 ## Screenshots
 
 ![sidebar](https://raw.githubusercontent.com/tgrosinger/recent-files-obsidian/main/resources/screenshots/sidebar.png)


### PR DESCRIPTION
* Right-clicking now opens a menu instead of opening the file
* Hover preview can be configured in "Page Preview" settings (requires ctrl by default)
* Documented feature parity with the builtin file explorer
* Fixed an issue where updating the plugin would not actually update the view implementation until Obsidian was reloaded.