### PR TITLE
Improve Hover Editor & Insider build support

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -138,7 +138,6 @@ class RecentFilesListView extends ItemView {
           menu,
           file,
           'link-context-menu',
-          this.leaf,
         );
         menu.showAtPosition({ x: event.clientX, y: event.clientY });
       });

--- a/main.ts
+++ b/main.ts
@@ -46,6 +46,9 @@ class RecentFilesListView extends ItemView {
 
     this.plugin = plugin;
     this.data = data;
+  }
+
+  public async onOpen(): Promise<void> {
     this.redraw();
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",
-    "target": "es5",
+    "target": "es2018",
     "allowJs": true,
     "noImplicitAny": true,
     "moduleResolution": "node",


### PR DESCRIPTION
My original PR (#22) for adding file menus to the plugin incorrectly passed a "leaf" argument when opening the file menu, which causes certain menu items to misbehave, especially in newer versions of Obsidian.  (It also prevents Hover Editor from adding a menu item to open the targeted file.)

This tiny patch resolves these issues by removing the leaf argument, which according to the Obsidian devs should not be passed unless the file in question is *in* the leaf (which it never is, in Recent Files' case).