### PR TITLE
Add support for the Front Matter Title plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-jsdoc": "30.7.3",
     "eslint-plugin-prefer-arrow": "1.2.2",
     "eslint-plugin-simple-import-sort": "5.0.3",
+    "front-matter-plugin-api-provider": "0.1.4-alpha",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/archive/1b4f6e2e5753c8ac2d538bc5d55c38f228450cb2.tar.gz",
     "rollup": "^2.32.1",
     "tslib": "^2.0.3",


### PR DESCRIPTION
This PR adds support to the [Front Matter Title](https://github.com/snezhig/obsidian-front-matter-title) Obsidian plugin. When setting the title of a note in the Recent Files List View, the plugin will check to see if the Front Matter Title plugin is enabled and if it is it will use Front Matter Title's title for the note.

I am using the [front-matter-plugin-api-provider](https://www.npmjs.com/package/front-matter-plugin-api-provider) that Front Matter Title provides to safely handle inter-plugin communication. If the Front Matter Title plugin is not installed in your vault the Recent Files plugin will not crash.

I hope that this PR finds you well. If you would like any changes to the PR, feel free to let me know :D

Edit: Just amended my commit to 1. add a little more documentation and 2. check if the query returns null or not. It is good to merge now, imo