### PR TITLE
Add optional display of last access time

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "Tony Grosinger",
   "license": "GPL-3.0",
   "devDependencies": {
+    "@types/moment": "2.13.0",
     "@types/node": "20.11.6",
     "@typescript-eslint/eslint-plugin": "6.19.1",
     "@typescript-eslint/parser": "6.19.1",

--- a/styles.css
+++ b/styles.css
@@ -3,12 +3,21 @@
   align-items: unset;
 }
 
-.recent-files-title-content {
+.recent-files-content {
   flex-grow: 1;
+}
+
+.recent-files-time-content {
+  filter: brightness(1.2);
+}
+
+.theme-dark .recent-files-time-content {
+  filter: brightness(0.8);
 }
 
 .recent-files-file-delete {
   display: none;
+  align-items: center;
 }
 
 .recent-files-title:hover .recent-files-file-delete {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "inlineSourceMap": true,
     "inlineSources": true,


### PR DESCRIPTION
This adds an option to display the time a file was last accessed:

![Obsidian_2024-06-14_21-29-41](https://github.com/tgrosinger/recent-files-obsidian/assets/904055/68ecf7ac-53c7-49da-bd4b-08ab97f1f7f9)

The timestamp is added via a data attribute to each entry, as well as the following situational classes:
`recent-files-this-hour`, `recent-files-this-day`, `recent-files-last-day`, `recent-files-this-week`, `recent-files-last-week`, `recent-files-this-month`, `recent-files-last-month`, `recent-files-this-year`, `recent-files-last-year`

![Obsidian_2024-06-14_21-29-31](https://github.com/tgrosinger/recent-files-obsidian/assets/904055/459e3e0b-dcae-4a8a-8b3b-0e3a812ec7ae)

The time can be displayed as relative or a user defined [Moment.js format](https://momentjs.com/docs/#/displaying/format/):

![2024-06-14_21-30-42](https://github.com/tgrosinger/recent-files-obsidian/assets/904055/4c43e886-dee5-4527-9074-96dea0ddda3d)

![Obsidian_2024-06-14_21-30-50](https://github.com/tgrosinger/recent-files-obsidian/assets/904055/8f50881d-db95-4f5f-a072-336326062367)

---

Things I'm not 100% on / need another pair of eyes on:
  - Typescript, specfically augmenting `FilePath`
  - Element layout and styles
  - Lots of Moment `isBetween`
  - Leaving the `timesFormat` setting empty to display relative times feels weird
  - Staleness: I don't think this is really a problem, but it can occur. _Maybe_ optionally redraw once every minute?

This fixes #39 and (maybe) #66.