### PR TITLE
Handle single line tags

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -419,10 +419,8 @@ export default class RecentFilesPlugin extends Plugin {
         }
       }
 
-      else if (Array.isArray(fileTags)) {
-        if (fileTags.some(tagMatch)) {
-          return false;
-        }
+      else if (fileTags.some(tagMatch)) {
+        return false;
       }
     }
 

--- a/main.ts
+++ b/main.ts
@@ -394,12 +394,35 @@ export default class RecentFilesPlugin extends Plugin {
         (tag) => tag.length > 0,
       );
 
-      // If there are no tags, the frontmatter.tags property is missing.
-      const fileTags: string[] = this.app.metadataCache.getFileCache(tfile)?.frontmatter?.tags || [];
+      /*
+       Tag(s) may be rendered in one of two ways. If only one tag is
+       present, as a string:
+       ```yaml
+       tags: mytag
+       ```
+
+       or, if one or more tags are present, in an array:
+       ```yaml
+       tags:
+        - tag1
+        - tag2
+       ```
+
+       If there are no tags, the `frontmatter.tags` property is missing.
+      */
+      const fileTags: string | string[] = this.app.metadataCache.getFileCache(tfile)?.frontmatter?.tags || [];
       const tagMatch = (tag: string): boolean => omittedTags.includes(tag);
 
-      if (fileTags.some(tagMatch)) {
-        return false;
+      if (typeof fileTags === 'string') {
+        if (tagMatch(fileTags)) {
+          return false;
+        }
+      }
+
+      else if (Array.isArray(fileTags)) {
+        if (fileTags.some(tagMatch)) {
+          return false;
+        }
       }
     }
 


### PR DESCRIPTION
Closes #101 .

A description as to why this occurs can be found [here](https://github.com/tgrosinger/recent-files-obsidian/issues/101#issuecomment-2455668806).

Might just be me who finds calling `tagMatch(fileTags)` then `fileTags.some(tagMatch)` confusing.

Any optimisations are welcome. 