### PR TITLE
Middle-click on navFile to open the file in a new window.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -212,7 +212,7 @@ class RecentFilesListView extends ItemView {
         this.focusFile(currentFile, newLeaf);
       });
 
-      navFileTitleContent.addEventListener('mousedown', (event: MouseEvent) => {
+      navFile.addEventListener('mousedown', (event: MouseEvent) => {
         if (!currentFile) return;
 
         if (event.button === 1) {


### PR DESCRIPTION
It seems that the file can only be opened in a new tab when the mouse hovers over the "text" area. 
For example, if there is a piece of text like: `Text Area                 `, clicking the middle mouse button on the Text Area will open the file in a new window. However, if the middle mouse button is clicked on the same line but on the blank space: `               `, the file will not open. I would like to see the ability to open the file in a new window even when clicking on the blank space.

[recent-files-obsidian-custom.zip](https://github.com/user-attachments/files/19802497/recent-files-obsidian-custom.zip)
