### PR TITLE
Add option showPath to hide or display before/after note name

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -32,3 +32,9 @@
 .recent-files-donate-button {
   margin: 10px;
 }
+
+.recent-files-title-path {
+  margin: 0px 5px;
+  font-size:0.85em;
+  color: var(--text-faint);
+}


### PR DESCRIPTION
I have notes with the same name in different directories and it can be confusing. Despite the name is shown when hovering the mouse, this is not convenient with many such files.

This PR addresses this issue by:
- Add an option to choose where to show the path. The default value is 'no' which preserves the current behavior (path isn't shown)
- the redraw() function wraps the current text into a span. Optionally it will add another span for the path. Both have proper classes for customization.

<img width="260" height="203" alt="Image" src="https://github.com/user-attachments/assets/46b5eb77-772e-4e5b-887f-59ab84d6c988" /> OR <img width="259" height="204" alt="Image" src="https://github.com/user-attachments/assets/c88519f9-1c70-4624-8e68-b9d1e6ad59bf" />

<img width="802" height="316" alt="image" src="https://github.com/user-attachments/assets/6731287f-2a05-40fe-a437-82e8c55c3ef6" />


Related: same user request https://github.com/tgrosinger/recent-files-obsidian/issues/128