### PR TITLE
Fix unnecessary saving every few seconds

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -358,8 +358,8 @@ export default class RecentFilesPlugin extends Plugin {
         this.data.recentFiles.length - toRemove,
         toRemove,
       );
+      await this.saveData();
     }
-    await this.saveData();
   };
 
   public readonly shouldAddFile = (file: FilePath): boolean => {
@@ -498,8 +498,9 @@ export default class RecentFilesPlugin extends Plugin {
       needsSave = true;
     }
 
+    await this.pruneLength();
     if (needsSave) {
-      await this.pruneLength(); // Handles the save
+      await this.saveData();
     }
   };
 


### PR DESCRIPTION
Recent files list was saved to disk every five seconds, even when there were no changes to the list.

I noticed Obsidian causing a file sync to icloud every few seconds and traced it to the Recent Files plugin triggering it.